### PR TITLE
Feature JuliaCon video and Example project

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,15 @@ heroku-buildpack-julia
 
 This is a [Heroku buildpack](https://devcenter.heroku.com/articles/buildpacks) for [Julia](http://julialang.org) apps.
 
-In order to use this buildpack simply use a project using Julia 1.0 (containing `Project.toml` & `Manifest.toml`) and the buildpack will install all the project dependencies in build time.
+[JuliCon 2019 Presentation Video](https://www.youtube.com/watch?v=p--assaV64g)
+
+[Example](https://github.com/Optomatica/heroku-julia-sample) project that uses this buildpack with Mux.jl.
+
+In order to use this buildpack simply use a project using Julia 1.1 (containing `Project.toml` & `Manifest.toml`) and the buildpack will install all the project dependencies in build time.
 
 Make sure you have a Procfile as follow 
 ```
 web: julia --project src/app.jl $PORT
 ```
 
-You can also replace `app.jl` with your main app file name. This is a [sample](https://github.com/Optomatica/heroku-julia-sample) that uses this buildpack with Mux.jl.
+You can also replace `app.jl` with your main app file name.


### PR DESCRIPTION
I passed-over this buildpack earlier because it didn't stand out as being easy test out compared to all the other julia buildpacks available.

Wanted to feature the example repo more prominently, and also include a link to your JuliaCon presentation.

Figured it would also be good to note that this buildpack supports julia 1.1.

It may also be worthwhile to include some more detailed usage commands in order to give users confidence this will be easy to test out. The example repo has a pull request for more detailed instructions, but visitors might make it through the example link.